### PR TITLE
Update node16 -> node20 [urgent] [nodejs16 deprecation]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: 'Specify the behavior of getting the variable. first_match, overwrite and fill are valid values.'
     default: 'first_match'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
The nodejs16 version will be deprecated in June 15th, 2024.

https://github.com/nodejs/Release#end-of-life-releases

This PR updates the action version to nodejs20.